### PR TITLE
chore (SPLAT-352): pin github actions to commit hash

### DIFF
--- a/.github/workflows/php-pr-checks.yml
+++ b/.github/workflows/php-pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e
         with:
           php-version: ${{ matrix.php_version }}
           # We don't run any coverage, so we should set this parameter to none


### PR DESCRIPTION
This pull request updates the PHP setup action in the GitHub workflow configuration to use a specific commit SHA instead of a version tag. 🤖